### PR TITLE
The first column must be moved into the index

### DIFF
--- a/download_clingraph_clinvec.ipynb
+++ b/download_clingraph_clinvec.ipynb
@@ -147,6 +147,7 @@
     "\n",
     "# load phecode embeddings\n",
     "df = pd.read_csv(\"ClinVec_phecode.csv\")\n",
+    "df = df.set_index(df.columns[0])\n",
     "\n",
     "# get matrix of embeddings\n",
     "emb_mat = df.values\n",


### PR DESCRIPTION
Why: 

In the section `Reading in ClinVec embeddings into Python` you do `df['node_index'] = df.index` but `df.index` by default takes the values between 0 and length of the array. 

The first column of the CSV stores the actual node indices, so that must be moved into the df index instead. 